### PR TITLE
Multiple choice2

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,14 @@ This is my collection of develop and debug tools for working with projects using
 ```lua
 return {
     "oyvindaakre/dtools.nvim",
+    dependencies = {
+        "mfussenegger/nvim-dap",
+    }
 }
 ```
 
 ## Configuration
-Dynamically configure the build directory for the current open buffer with a custom function:
+Dynamically set which build directory that belongs to the currently open buffer with a custom function:
 ```lua
 local dtools = require("dtools")({
     builddir = function(bufnr)
@@ -21,12 +24,16 @@ local dtools = require("dtools")({
             return "build"
         end
     end,
+
+    --- Add a keymap to run the plugin
+    vim.keymap.set("n", "<leader>dt", dtools.debug_test, { desc = "[D]ebug: [T]est" })
 })
 ```
 
 ## Example: Configuration for debugging a unit test
 This configuration adds a new entry for debugging `.c`-files anmed "Debug unit test".
-With this you should be able to place your cursor at or below the test function that you want to debug and when selecting the new configuration, a debug session will start for that particular function. 
+With this you should be able to place your cursor at or below the test function that you want to debug and 
+when triggering `dtools.debug_test(), a debug session will start for that particular function.
 ```lua
 --- Somewhere in your debug configuration
 local dap = require("dap")
@@ -40,6 +47,7 @@ local dtools = require("dtools")({
             return "build"
         end
     end,
+    vim.keymap.set("n", "<leader>dt", dtools.debug_test, { desc = "[D]ebug: [T]est" })
 })
 
 --- Configure native GDB debug adapter
@@ -50,17 +58,18 @@ dap.adapters.gdb = {
 }
 
 --- Add a configuration for debugging unit tests
+--- Note that this is automatically called when you first call dtools.debug_test()
 local debug_unit_test = {
     name = "Debug unit test",
     type = "gdb",
     request = "attach",
     program = function()
-        local _, err = dtools.start_debug_server()
+        local exe, err = dtools.start_debug_server()
         if err ~= nil then
             print(err)
             return nil
         end
-        return dtools.get_executable_at_cursor()
+        return exe 
     end,
     cwd = "${workspaceFolder}",
     stopAtBeginningOfMainSubprogram = true,

--- a/lua/dtools.lua
+++ b/lua/dtools.lua
@@ -13,22 +13,33 @@ local M = {
   options = {},
 }
 
----Start a debug server in a new process to debug the test closest to the current line
+---Start a debug server in a new process to debug the test closest to the current line that was found by calling dtools.debug_test()
 ---Returns the connection string to the debug server (e.g. localhost:1234) or nil and an optional error message
 ---@return string | nil, string | nil
 function M.start_debug_server()
+  if M.test_exe == "" or M.test_suite == "" or M.test_name == "" then
+    return nil, "Error: Need to call dtools.debug_test() first"
+  end
+
   local pid = criterion.start_debug_server(M.test_exe, M.test_suite, M.test_name)
   if pid <= 0 then
     return nil, "Failed to start debug server"
   end
 
   print("Starting debug server")
-  return "localhost:1234", nil
+  return M.test_exe, nil
 end
 
----Get the test executable that implements the test closest to the cursor
----@return string | nil, string | nil
-function M.get_executable_at_cursor()
+---Debug the test under the cursor
+---This is the pimary API for starting a debug session and must be called at least once.
+---When this function is called, the module will try to find the test executable that implements the test under the cursor.
+---An input list will be shown if there are multiple options.
+---Next it finds the name of the suite and test closest to the cursor.
+---All metadata is stored in the module before it automatically calls `dap.continue`.
+---At this point dap takes over to start the debug session.
+---NOTE: You can repeat the previous debug session by calling dap.continue manually.
+---@return boolean, string | nil
+function M.debug_test()
   M.test_exe = ""
   M.test_suite = ""
   M.test_name = ""
@@ -39,28 +50,41 @@ function M.get_executable_at_cursor()
 
   local line = criterion.get_nearest_test(bufnr, cursor_pos)
   if line == "" then
-    return nil, "No test to run"
+    return false, "No test to run"
   end
 
   local builddir = M.options.builddir and M.options.builddir(bufnr) or "build"
   local test_exe = util.get_test_exe_from_buffer(bufnr, builddir)
-  print("Debug exe: " .. vim.inspect(test_exe))
 
   if test_exe == nil then
-    return nil, "No test executable was found in " .. builddir
+    return false, "No test executable was found in " .. builddir
   end
 
   local test = criterion.get_test_suite_and_name(line)
   if test == nil then
-    return nil, "Failed to parse test suite and name"
+    return false, "Failed to parse test suite and name"
   end
 
-  M.test_exe = test_exe
-  M.test_name = test.test_name
-  M.test_suite = test.test_suite
-  print("dtools: " .. vim.inspect(M))
+  if #test_exe == 1 then
+    M.test_exe = test_exe[1]
+    M.test_name = test.test_name
+    M.test_suite = test.test_suite
+    require("dap").continue()
+  else
+    vim.ui.select(test_exe, {
+      prompt = "Multiple tests available, please select:",
+      format_item = function(item)
+        return util.get_filename(item)
+      end,
+    }, function(choice)
+      M.test_exe = choice
+      M.test_name = test.test_name
+      M.test_suite = test.test_suite
+      require("dap").continue()
+    end)
+  end
 
-  return M.test_exe
+  return true
 end
 
 --- Plugin options

--- a/lua/dtools.lua
+++ b/lua/dtools.lua
@@ -6,6 +6,9 @@ local criterion = require("dtools.criterion")
 ---@field additional_args (fun(buf: integer): string[])?
 
 local M = {
+  test_exe = "",
+  test_suite = "",
+  test_name = "",
   ---@type DtoolsOptions
   options = {},
 }
@@ -14,6 +17,22 @@ local M = {
 ---Returns the connection string to the debug server (e.g. localhost:1234) or nil and an optional error message
 ---@return string | nil, string | nil
 function M.start_debug_server()
+  local pid = criterion.start_debug_server(M.test_exe, M.test_suite, M.test_name)
+  if pid <= 0 then
+    return nil, "Failed to start debug server"
+  end
+
+  print("Starting debug server")
+  return "localhost:1234", nil
+end
+
+---Get the test executable that implements the test closest to the cursor
+---@return string | nil, string | nil
+function M.get_executable_at_cursor()
+  M.test_exe = ""
+  M.test_suite = ""
+  M.test_name = ""
+
   local bufnr = vim.api.nvim_get_current_buf()
   local win = vim.api.nvim_get_current_win() -- Get the current active window
   local cursor_pos = vim.api.nvim_win_get_cursor(win) -- Get the cursor position in the window
@@ -25,8 +44,9 @@ function M.start_debug_server()
 
   local builddir = M.options.builddir and M.options.builddir(bufnr) or "build"
   local test_exe = util.get_test_exe_from_buffer(bufnr, builddir)
+  print("Debug exe: " .. vim.inspect(test_exe))
 
-  if test_exe == "" then
+  if test_exe == nil then
     return nil, "No test executable was found in " .. builddir
   end
 
@@ -35,21 +55,12 @@ function M.start_debug_server()
     return nil, "Failed to parse test suite and name"
   end
 
-  local pid = criterion.start_debug_server(test_exe, test.test_suite, test.test_name)
-  if pid <= 0 then
-    return nil, "Failed to start debug server"
-  end
+  M.test_exe = test_exe
+  M.test_name = test.test_name
+  M.test_suite = test.test_suite
+  print("dtools: " .. vim.inspect(M))
 
-  return "localhost:1234", nil
-end
-
----Get the test executable that implements the test closest to the cursor
----@return string | nil
-function M.get_executable_at_cursor()
-  local current_buffer = vim.api.nvim_get_current_buf()
-  local builddir = M.options.builddir and M.options.builddir(current_buffer) or "build"
-  local test_exe = util.get_test_exe_from_buffer(current_buffer, builddir)
-  return test_exe
+  return M.test_exe
 end
 
 --- Plugin options

--- a/lua/dtools/criterion.lua
+++ b/lua/dtools/criterion.lua
@@ -113,15 +113,10 @@ function M.start_debug_server(test_exe, test_suite, test_name)
     on_stderr = function(_, data)
       print(data)
     end,
-    on_exit = function(_, return_val)
-      retval = return_val
-    end,
+    on_exit = function(_, return_val) end,
   })
   job:start()
 
-  if retval ~= 0 then
-    return -1
-  end
   return job.pid
 end
 return M

--- a/lua/dtools/util.lua
+++ b/lua/dtools/util.lua
@@ -72,7 +72,7 @@ end
 ---so that is a known limitation and is currently not handled.
 ---@param bufnr integer
 ---@param builddir string
----@return string | nil
+---@return any
 function M.get_test_exe_from_buffer(bufnr, builddir)
   local bufname = vim.api.nvim_buf_get_name(bufnr)
   local targets = meson.get_targets(builddir)
@@ -85,37 +85,15 @@ function M.get_test_exe_from_buffer(bufnr, builddir)
       for _, source in ipairs(target_source["sources"]) do
         -- print(vim.inspect(source))
         if source == bufname then
-          print("Found exe: " .. target["filename"][1])
+          -- print("Found exe: " .. target["filename"][1])
           table.insert(exe_found, target["filename"][1])
         end
       end
     end
   end
 
-  print("Num exes found: " .. tostring(#exe_found))
-
-  if #exe_found == 1 then
-    return exe_found[1]
-  end
-
-  -- local selected_exe = nil
-  -- vim.ui.select(exe_found, {
-  --   prompt = "Multiple tests available, please select:",
-  --   format_item = function(item)
-  --     print("Formatting item: " .. vim.inspect(item))
-  --     return M.get_filename(item)
-  --   end,
-  -- }, function(choice)
-  --   print("User selected: " .. vim.inspect(choice))
-  --   selected_exe = choice
-  -- end)
-  -- print("Hello?")
-  local choice = vim.fn.inputlist(exe_found)
-  if choice < 1 or choice > #exe_found then
-    return nil
-  end
-
-  return exe_found[choice]
+  -- print("Num exes found: " .. tostring(#exe_found))
+  return exe_found
 end
 
 return M

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -9,3 +9,10 @@ exe = executable(
 )
 
 test(exe.name(), exe)
+
+exe = executable(
+  'test_example_other',
+  'test_example.c',
+  dependencies: dependency('criterion'),
+)
+test(exe.name(),  exe)


### PR DESCRIPTION
This PR adds breaking changes, please see b50d548bb4b346aa333d710fd948240d8ec4c5a3.

## New
If there exists multiple executables that implements the test function then the user can now select the correct one from a floating input view. Debugging can start once a choice has been made. If there is only 1 option then debugging starts immediately.  

It is now mandatory to call the new API `dtools.debug_test()` to trigger a new debug session. 
The dap configuration also needs to change so that it calls `dtools.start_debug_server()` to now retrieve the name of the test executable. See the README for details.