### PR TITLE
feat: Add API to insert C-style header guards

### DIFF
--- a/lua/dtools/header.lua
+++ b/lua/dtools/header.lua
@@ -1,0 +1,17 @@
+local util = require("dtools.util")
+
+local M = {}
+
+function M.insert_header_guard()
+  local bufname = vim.api.nvim_buf_get_name(0)
+  local filename = util.get_filename(bufname)
+  local guardname = util.splitstr(filename, ".")[1] or ""
+
+  guardname = string.upper(guardname) .. "_H"
+
+  vim.api.nvim_buf_set_lines(0, 0, 0, true, { "#ifndef " .. guardname })
+  vim.api.nvim_buf_set_lines(0, 1, 1, true, { "#define " .. guardname })
+  vim.api.nvim_buf_set_lines(0, -1, -1, true, { "#endif //" .. guardname })
+end
+
+return M


### PR DESCRIPTION
Use the name of the current buffer, make it uppercase and append "_H". 

Example: some_module.h -> SOME_MODULE_H